### PR TITLE
Add format_support short_type_name tests

### DIFF
--- a/rustecal-types-serde/tests/format_support.rs
+++ b/rustecal-types-serde/tests/format_support.rs
@@ -1,0 +1,15 @@
+use rustecal_types_serde::format_support::{self, FormatSupport};
+
+#[test]
+fn short_type_name_for_trait() {
+    assert_eq!(format_support::short_type_name::<FormatSupport>(), "FormatSupport");
+}
+
+mod nested {
+    pub struct Inner;
+}
+
+#[test]
+fn short_type_name_for_nested_type() {
+    assert_eq!(format_support::short_type_name::<nested::Inner>(), "Inner");
+}


### PR DESCRIPTION
## Summary
- add unit tests for `short_type_name` in `format_support`

## Testing
- `cargo test -p rustecal-types-serde` *(fails: failed to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6849ef989ea48332b39262754b9f06b3